### PR TITLE
Use path prefix to support github pages hosting

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -10,6 +10,6 @@ const routes = [{
 	component: Home
 }];
 
-const router = new VueRouter({ routes });
+const router = new VueRouter({ routes, base: '/site/' });
 
 export default router;


### PR DESCRIPTION
The github pages website is broken because it tries to request the resources from the root of the domain, when it should be from `/site/`, this should fix.